### PR TITLE
JIR-7919 Updated string for zoom permission message to include Nearby Device string

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -10,6 +10,9 @@
                 <param name="android-package" value="cordova.plugin.zoom.Zoom" />
             </feature>
         </config-file>
+       <config-file target="res/values/strings.xml" parent="/*">
+        <string name="zm_msg_meeting_permission">For the best meeting experience, Zoom may ask to access to your microphone, camera, nearby devices and storage.</string>
+       </config-file> 
         <config-file parent="/*" target="AndroidManifest.xml">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
             <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
Zoom latest SDK provides support for Android 12 and is handling the needed permissions. Zoom mainly uses bluetooth ‘nearby devices’ while connecting video calls via bluetooth headphones.

In our apps, when we start the zoom calls, zoom asks for new bluetooth permissions (Nearby devices) but No appropriate message is being shown by zoom related to it.

Currently the permissions related message shown by Zoom android SDK is _"For the best meeting experience, Zoom may ask to access to your microphone, camera, and storage."_

We need to inform the user about allowing Nearby devices permission also as we are doing it on our PCM app.

As zoom is already informing about the other permissions, in this case instead of showing one more pop-up for nearby devices, we are making changes to the zoom plugin code.

We overwrite the string entry for permissions and change it to _"For the best meeting experience, Zoom may ask to access to your microphone, camera, nearby devices and storage."_