### PR TITLE
Android - Switch to gallery view when user count reached 3

### DIFF
--- a/src/android/Zoom.java
+++ b/src/android/Zoom.java
@@ -20,6 +20,7 @@ import android.content.DialogInterface;
 import us.zoom.sdk.ChatMessageDeleteType;
 import us.zoom.sdk.FreeMeetingNeedUpgradeType;
 import us.zoom.sdk.InMeetingChatController;
+import us.zoom.sdk.InMeetingUserList;
 import us.zoom.sdk.MeetingParameter;
 import us.zoom.sdk.VideoQuality;
 import us.zoom.sdk.ZoomSDK;
@@ -49,6 +50,8 @@ import us.zoom.sdk.JoinMeetingParams;
 import us.zoom.sdk.JoinMeetingOptions;
 
 import cordova.plugin.zoom.AuthThread;
+import us.zoom.sdk.ZoomUIService;
+
 /**
  * Zoom
  *
@@ -409,6 +412,9 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
         msHelper.setAutoConnectVoIPWhenJoinMeeting(true);
         msHelper.enableForceAutoStartMyVideoWhenJoinMeeting(true);
         msHelper.disableShowVideoPreviewWhenJoinMeeting(true);
+        // to switch to gallery view automatically when user count threshold reaches
+        msHelper.setSwitchVideoLayoutUserCountThreshold(2);
+        msHelper.setSwitchVideoLayoutAccordingToUserCountEnabled(true);
 
         JoinMeetingParams params = new JoinMeetingParams();
 
@@ -1218,10 +1224,26 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
     public void onMeetingFail(int i, int i1) {}
 
     @Override
-    public void onMeetingUserJoin(List<Long> list) {}
+    public void onMeetingUserJoin(List<Long> list) {
+        InMeetingService userList = ZoomSDK.getInstance().getInMeetingService();
+        ZoomUIService zoomUIService =  ZoomSDK.getInstance().getZoomUIService();
+        if(userList.getInMeetingUserList()!=null && userList.getInMeetingUserList().size()>=3) { 
+            zoomUIService.switchToVideoWall(); // gallery view
+        } else {
+            zoomUIService.switchToActiveSpeaker(); // switch to speaker view
+        }
+    }
 
     @Override
-    public void onMeetingUserLeave(List<Long> list) {}
+    public void onMeetingUserLeave(List<Long> list) {
+        InMeetingService userList = ZoomSDK.getInstance().getInMeetingService();
+        ZoomUIService zoomUIService =  ZoomSDK.getInstance().getZoomUIService();
+        if(userList.getInMeetingUserList()!=null && userList.getInMeetingUserList().size() < 3) {
+            zoomUIService.switchToActiveSpeaker();
+        } else {
+            zoomUIService.switchToVideoWall();
+        }
+    }
 
     @Override
     public void onMeetingUserUpdated(long l) {}


### PR DESCRIPTION
Currently on PC 3.0.X, if a Clinician and a patient are on a call, adding another clinician or user will result in the patient NOT being able to see the added person UNTIL they swipe left on their screen.

This was reported as a issue where now we have fixed that as soon as the third user joins the call, view will switch to Gallery view. 

The recommended method from Zoom, setSwitchVideoLayoutAccordingToUserCountEnabled(true) was not working as expected and we have communicated this to zoom. As per another suggestion, now we are utilising switchToVideoWall and switchToActiveSpeaker methods to do this switch. 

- Utilised InMeetingServiceListener which was already registered in the zoom code, listened to the events "onMeetingUserJoin" and "onMeetingUserLeave"

- In the method onMeetingUserJoin and onMeetingUserLeave, checked whether the current participant list size is >=3, if yes, then used ZoomUIService's switchToVideoWall() else switchToActiveSpeaker()
