### PR TITLE
DEV-15001 Fix crash on PCM builds

### DIFF
--- a/src/android/NewZoomMeetingActivity.java
+++ b/src/android/NewZoomMeetingActivity.java
@@ -16,7 +16,9 @@ import timber.log.Timber;
 
 public class NewZoomMeetingActivity extends NewMeetingActivity {
 
-    private String appResourcesPackage = getPackageName();
+    // NOTE: should not be initialized until onCreate(), otherwise
+    // this will crash non-tablet builds
+    private String appResourcesPackage = null;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
remove inline initializer that would cause PCM builds to crash when attempting to open the zoom activity (Android 13)