### PR TITLE
DEV-16779: Changes for call getting disconnected when put in bg

### DIFF
--- a/src/android/NewZoomMeetingActivity.java
+++ b/src/android/NewZoomMeetingActivity.java
@@ -1,8 +1,11 @@
 package cordova.plugin.zoom;
 
-import android.app.ActivityOptions;
+import android.app.Activity;
+import android.app.Application;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
@@ -10,26 +13,88 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 
-import androidx.core.app.ActivityCompat;
-
+import timber.log.Timber;
 import us.zoom.sdk.CustomizedMiniMeetingViewSize;
+import us.zoom.sdk.InMeetingService;
 import us.zoom.sdk.MeetingService;
 import us.zoom.sdk.NewMeetingActivity;
 import us.zoom.sdk.ZoomSDK;
 import us.zoom.sdk.ZoomUIService;
 
-import timber.log.Timber;
-
 public class NewZoomMeetingActivity extends NewMeetingActivity {
 
     private String appResourcesPackage;
+
+    private Context cordovaContext;
     private static LinearLayout userWaitingLayout;
     private static FrameLayout containerInConf;
 
+    private final CustomActivityLifecycleCallbacks mCallbacks = new CustomActivityLifecycleCallbacks();
+
+    public class CustomActivityLifecycleCallbacks implements Application.ActivityLifecycleCallbacks {
+
+        @Override
+        public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+            Timber.i("onCreate(): " + activity.getClass().getSimpleName());
+        }
+
+        @Override
+        public void onActivityStarted(Activity activity) {
+            Timber.i("onStart(): " + activity.getClass().getSimpleName());
+        }
+
+        @Override
+        public void onActivityResumed(Activity activity) {
+            Timber.i("onResume(): " + activity.getClass().getSimpleName());
+        }
+
+        @Override
+        public void onActivityPaused(Activity activity) {
+            Timber.i("onPause(): " + activity.getClass().getSimpleName());
+        }
+
+        @Override
+        public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+            Timber.i("onSaveInstanceState(): " + activity.getClass().getSimpleName());
+        }
+
+        @Override
+        public void onActivityStopped(Activity activity) {
+            Timber.i("onStop(): " + activity.getClass().getSimpleName());
+        }
+
+        @Override
+        public void onActivityDestroyed(Activity activity) {
+            Timber.i("onDestroy(): " + activity.getClass().getSimpleName());
+            // ZmConfPipActivity (PiP mode zoom SDK's activity
+            // We dont have callbacks from Zoom SDK when PiP mode is exited/destroyed. Thus we listen to this event and show the maximised view of the zoom call
+            if (activity.getClass().getSimpleName().contains("ZmConfPipActivity")) {
+                InMeetingService inMeetingService = ZoomSDK.getInstance().getInMeetingService();
+                if (inMeetingService.isMeetingConnected()) {
+                    String activityToStart = "cordova.plugin.zoom.NewZoomMeetingActivity";
+                    Timber.d("Ongoing zoom call, next activity to start " + activityToStart);
+                    try {
+                        Class<?> c = Class.forName(activityToStart);
+                        Intent intent = new Intent(NewZoomMeetingActivity.this, c);
+                        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+                        startActivity(intent);
+                    } catch (ClassNotFoundException ignored) {
+                        Timber.e("Unable to start " + ignored);
+                    }
+                }
+            }
+        }
+    }
+
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        // Always register before calling into the super class.
+        getApplication().registerActivityLifecycleCallbacks(mCallbacks);
         super.onCreate(savedInstanceState);
-        Timber.d("NewZoomMeetingActivity oncreate " + this);
+        cordovaContext = Zoom.getInstance().cordova.getContext();
+
+        Timber.d("NewZoomMeetingActivity oncreate " + this + " cordova context " + cordovaContext);
         appResourcesPackage = getPackageName();
 
         /**
@@ -57,12 +122,13 @@ public class NewZoomMeetingActivity extends NewMeetingActivity {
         });
 
         LayoutInflater li = LayoutInflater.from(this);
-        userWaitingLayout =  (LinearLayout) li.inflate(getResources().getIdentifier("zoom_user_waiting_layout", "layout", appResourcesPackage), null, false);
+        userWaitingLayout = (LinearLayout) li.inflate(getResources().getIdentifier("zoom_user_waiting_layout", "layout", appResourcesPackage), null, false);
         containerInConf = (FrameLayout) findViewById(getResources().getIdentifier("container_in_conf", "id", appResourcesPackage));
+
     }
 
     public static void enableWaitingMessage(boolean show) {
-        if(show) {
+        if (show) {
             containerInConf.addView(userWaitingLayout);
         } else {
             containerInConf.removeView(userWaitingLayout);
@@ -73,13 +139,15 @@ public class NewZoomMeetingActivity extends NewMeetingActivity {
     public void onDestroy() {
         Timber.d("NewZoomMeetingActivity on destroy " + this);
         super.onDestroy();
+        cordovaContext = null;
+        // Always unregister after calling into the super class.
+        getApplication().unregisterActivityLifecycleCallbacks(mCallbacks);
     }
 
     @Override
     protected void onPause() {
         Timber.d("Zoom on pause " + this);
         super.onPause();
-
     }
 
     @Override
@@ -108,11 +176,10 @@ public class NewZoomMeetingActivity extends NewMeetingActivity {
     }
 
     private void endMeetingAndMoveToActivity() {
-        Timber.d("end zoom call and start main activity");
+        Timber.d("End zoom call and start main activity " + Zoom.getInstance());
         if (Zoom.getInstance() != null) {
             Zoom.getInstance().leaveMeeting();
-        }
-        else { // app was minimised and app instance is no more thus handling this within this instance and re-launching the main activity
+        } else { // app was minimised and app instance is no more thus handling this within this instance and re-launching the main activity
             Timber.d("Started new activity instance as app instance was not found");
             ZoomUIService zoomUIService = ZoomSDK.getInstance().getZoomUIService();
             zoomUIService.hideMiniMeetingWindow();
@@ -124,17 +191,18 @@ public class NewZoomMeetingActivity extends NewMeetingActivity {
 
     private void startMainActivity() {
         String activityToStart = getPackageName() + ".MainActivity";
-        Timber.d("activity to start " + activityToStart);
+        Timber.d("Start MainActivity " + activityToStart);
         try {
             Class<?> c = Class.forName(activityToStart);
-            Intent intent = new Intent(this, c);
+            Log.d("NewZoomMeetingActivity", "Zoom instance when launching MainActivity " + Zoom.getInstance());
+            Intent intent = new Intent(cordovaContext, c);
             intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-            Bundle bundleAnim =  ActivityOptions.makeCustomAnimation(this, android.R.anim.slide_in_left, android.R.anim.slide_out_right).toBundle();
-            ActivityCompat.startActivity(this, intent, bundleAnim);
+            startActivity(intent);
         } catch (ClassNotFoundException ignored) {
             Timber.e("unable to start " + ignored);
         }
     }
+
 }
 
 


### PR DESCRIPTION
In this MR, following has been handled:
- When zoom call was minimised and then the app was put in background, the call was getting disconnected. This was due to different task stacks being used by our app and the com.zipow.videobox.conference.ui.ZmConfPipActivity from Zoom SDKs. To fix this, earlier we were using launchmode as singleInstance for NewZoomActivity and now we use the default one.
- There are zoom issues wrt call getting in the background when maximised. To fix this, we now listen to lifecycle callbacks for ZmConfPipActivity and when it is destroyed, we bring the NewZoonActivity to front to show it. 