### PR TITLE
DEV-17303 [PCM/T] App stops receiving push-notifications after minimized Zoom call ends

### DIFF
--- a/src/android/NewZoomMeetingActivity.java
+++ b/src/android/NewZoomMeetingActivity.java
@@ -1,6 +1,8 @@
 package cordova.plugin.zoom;
 
-import static cordova.plugin.zoom.Zoom.CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS;
+import static cordova.plugin.zoom.Zoom.ACTION_CALL_DECLINED_BY_PARTICIPANT;
+import static cordova.plugin.zoom.Zoom.ACTION_CALL_IGNORED_BY_PARTICIPANT;
+import static cordova.plugin.zoom.Zoom.ACTION_PARTICIPANTS_LEFT_THE_CALL;
 
 import android.app.Activity;
 import android.app.Application;
@@ -175,23 +177,27 @@ public class NewZoomMeetingActivity extends NewMeetingActivity {
                 public void run()    {
                     int nextAction = intent.getExtras().getInt("NextAction");
                     switch(nextAction) {
-                        case Zoom.ACTION_CALL_DECLINED_BY_PARTICIPANT:
+                        case ACTION_CALL_DECLINED_BY_PARTICIPANT:
                             Timber.d("Action -> Call declined by participant");
-                            Zoom.getInstance().showMessageDialog("zoom_call_declined_message", CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS);
+                            Zoom.getInstance().showMessageDialog(ACTION_CALL_DECLINED_BY_PARTICIPANT);
                             break;
 
-                        case Zoom.ACTION_CALL_IGNORED_BY_PARTICIPANT:
+                        case ACTION_CALL_IGNORED_BY_PARTICIPANT:
                             Timber.d("Action -> Call ignored by participant");
                             InMeetingService meetingService = ZoomSDK.getInstance().getInMeetingService();
                             List<Long> currentUserList = meetingService.getInMeetingUserList();
                             if (meetingService != null && currentUserList != null && currentUserList.size() <= 1) {
-                                Zoom.getInstance().showMessageDialog("zoom_call_missed_message", CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS); // inform user that call was ignored/missed by the other participant
+                                Zoom.getInstance().showMessageDialog(ACTION_CALL_IGNORED_BY_PARTICIPANT); // inform user that call was ignored/missed by the other participant
                             }
                             break;
 
-                        case Zoom.ACTION_PARTICIPANTS_LEFT_THE_CALL:
+                        case ACTION_PARTICIPANTS_LEFT_THE_CALL:
                             Timber.d("Action -> Participant left the call");
                             Zoom.getInstance().leaveMeeting();
+                            break;
+
+                        default:
+                            Timber.d("Default case onNewIntent Zoom");
                             break;
                     }
                 }

--- a/src/android/NewZoomMeetingActivity.java
+++ b/src/android/NewZoomMeetingActivity.java
@@ -1,10 +1,14 @@
 package cordova.plugin.zoom;
 
+import static cordova.plugin.zoom.Zoom.CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS;
+
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -12,6 +16,8 @@ import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+
+import java.util.List;
 
 import timber.log.Timber;
 import us.zoom.sdk.CustomizedMiniMeetingViewSize;
@@ -154,6 +160,43 @@ public class NewZoomMeetingActivity extends NewMeetingActivity {
     protected void onResume() {
         Timber.d("Zoom on resume " + this);
         super.onResume();
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        Timber.d("NewZoomMeetingActivity onNewIntent");
+        if(intent!=null && intent.getExtras()!=null) {
+            Timber.d("Intent NextAction: " + intent.getExtras().get("NextAction"));
+            Handler mainHandler = new Handler(Looper.getMainLooper());
+            mainHandler.post(new Runnable()
+            {
+                @Override
+                public void run()    {
+                    int nextAction = intent.getExtras().getInt("NextAction");
+                    switch(nextAction) {
+                        case Zoom.ACTION_CALL_DECLINED_BY_PARTICIPANT:
+                            Timber.d("Action -> Call declined by participant");
+                            Zoom.getInstance().showMessageDialog("zoom_call_declined_message", CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS);
+                            break;
+
+                        case Zoom.ACTION_CALL_IGNORED_BY_PARTICIPANT:
+                            Timber.d("Action -> Call ignored by participant");
+                            InMeetingService meetingService = ZoomSDK.getInstance().getInMeetingService();
+                            List<Long> currentUserList = meetingService.getInMeetingUserList();
+                            if (meetingService != null && currentUserList != null && currentUserList.size() <= 1) {
+                                Zoom.getInstance().showMessageDialog("zoom_call_missed_message", CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS); // inform user that call was ignored/missed by the other participant
+                            }
+                            break;
+
+                        case Zoom.ACTION_PARTICIPANTS_LEFT_THE_CALL:
+                            Timber.d("Action -> Participant left the call");
+                            Zoom.getInstance().leaveMeeting();
+                            break;
+                    }
+                }
+            });
+        }
     }
 
     @Override

--- a/src/android/Zoom.java
+++ b/src/android/Zoom.java
@@ -359,12 +359,25 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
 
     private void handleCallStatusUpdate(String callStatus) {
         if (callStatus!=null && callStatus.equals(CALL_STATUS_DECLINED)) {
-            cordova.getActivity().runOnUiThread(
-                new Runnable() {
-                    public void run() {
-                        showMessageDialog("zoom_call_declined_message", CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS);
-                    }
-                });
+            // when call is declined, and call is on, show the NewZoomMeeting first and then launch the dialog
+
+            Handler mainHandler = new Handler(Looper.getMainLooper());
+            // Send a task to the MessageQueue of the main thread
+            mainHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    Timber.d("OnGoing Zoom call received declined from other party, meeting in progress, show NewZoomMeetingActivity");
+                    reorderNewZoomActivity();
+                }
+            });
+
+            mainHandler.postDelayed(new Runnable()
+            {
+                @Override
+                public void run()    {
+                    showMessageDialog("zoom_call_declined_message", CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS);
+                }
+            }, 1000);
 
         }
     }
@@ -1680,17 +1693,33 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
         emitSharedJsEvent(EVENT_TYPE_MEETING_USER_JOIN, eventData);
     }
 
+    /**
+     * If the call is ignored by other participant and no one joins it, we show the maximised call view and then a
+     * dialog that will auto leave the call / or user can end it by pressing ok.
+     */
     private void checkCallIgnoredByParticipant() {
-        cordova.getActivity().runOnUiThread(
-            new Runnable() {
-                public void run() {
+
+        Handler mainHandler = new Handler(Looper.getMainLooper());
+        // Send a task to the MessageQueue of the main thread
+        mainHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                    Timber.d("Call ignored by participant, meeting in progress, show NewZoomMeetingActivity");
+                    reorderNewZoomActivity();
+            }
+        });
+
+        mainHandler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
                     InMeetingService meetingService = ZoomSDK.getInstance().getInMeetingService();
                     List<Long> currentUserList = meetingService.getInMeetingUserList();
                     if (meetingService != null && currentUserList != null && currentUserList.size() <= 1) {
                         showMessageDialog("zoom_call_missed_message", CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS); // inform user that call was ignored/missed by the other participant
                     }
-                }
-            });
+            }
+        }, 1000);
+
     }
 
     @Override
@@ -1713,7 +1742,41 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
 
         emitSharedJsEvent(EVENT_TYPE_MEETING_USER_LEAVE, eventData);
         if (currentUserList !=null && currentUserList.size() == 1) {
-            leaveMeeting();
+            
+            Handler mainHandler = new Handler(Looper.getMainLooper());
+            // Send a task to the MessageQueue of the main thread
+            mainHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                        Timber.d("Call left by all other participants, meeting in progress, show NewZoomMeetingActivity");
+                        reorderNewZoomActivity();
+                }
+            });
+
+            // End the call as the user is the last participant left
+            mainHandler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    leaveMeeting();
+                }
+            }, 1000);
+
+        }
+    }
+
+    private void reorderNewZoomActivity() {
+        InMeetingService inMeetingService = ZoomSDK.getInstance().getInMeetingService();
+        if (inMeetingService.isMeetingConnected()) {
+            String activityToStart = "cordova.plugin.zoom.NewZoomMeetingActivity";
+            try {
+                Class<?> c = Class.forName(activityToStart);
+                Intent intent = new Intent(cordova.getActivity(), c);
+                intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+                Bundle bundleAnim =  ActivityOptions.makeCustomAnimation(cordova.getActivity(), android.R.anim.slide_in_left, android.R.anim.slide_out_right).toBundle();
+                ActivityCompat.startActivity(cordova.getContext(), intent, bundleAnim);
+            } catch (ClassNotFoundException ignored) {
+                Timber.e("Unable to start " + ignored);
+            }
         }
     }
 

--- a/src/android/Zoom.java
+++ b/src/android/Zoom.java
@@ -1776,7 +1776,7 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
                             btnPositive.setBackgroundColor(Color.DKGRAY);
                         }
                     });
-                    if (context != null && (context instanceof Activity && !((AppCompatActivity) context).isFinishing())) {
+                    if(context != null && (context instanceof Activity && !((AppCompatActivity) context).isFinishing())) {
                         messageDialog.show();
                         TextView textView = (TextView) messageDialog.findViewById(android.R.id.message);
                         textView.setTextSize(20);
@@ -1785,11 +1785,10 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
                     }
 
                     int correctedAutoDismissTimeInMillis = autoDismissTimeInMillis + 1000; // countdown timer's onTick callback provides millisUntilFinished, it almost passes few millis until we get the callback and we need to display the start value value
-                    String countdownMsgID = messageID;
                     new CountDownTimer(correctedAutoDismissTimeInMillis, 1000) { // show the countdown on the dialog
                         public void onTick(long millisUntilFinished) {
-                            if (messageDialog != null && messageDialog.isShowing()) {
-                                int resId = cordova.getActivity().getResources().getIdentifier(countdownMsgID, "string", cordova.getActivity().getPackageName());
+                            if(messageDialog != null && messageDialog.isShowing()) {
+                                int resId = cordova.getActivity().getResources().getIdentifier(messageID, "string", cordova.getActivity().getPackageName());
                                 String message = cordova.getActivity().getString(resId, String.valueOf(millisUntilFinished / 1000));
                                 messageDialog.setMessage(message);
                             }

--- a/src/android/Zoom.java
+++ b/src/android/Zoom.java
@@ -1776,7 +1776,7 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
                             btnPositive.setBackgroundColor(Color.DKGRAY);
                         }
                     });
-                    if(context != null && (context instanceof Activity && !((AppCompatActivity) context).isFinishing())) {
+                    if(context != null && (context instanceof Activity && !((AppCompatActivity) context).isFinishing())){
                         messageDialog.show();
                         TextView textView = (TextView) messageDialog.findViewById(android.R.id.message);
                         textView.setTextSize(20);
@@ -1787,7 +1787,7 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
                     int correctedAutoDismissTimeInMillis = autoDismissTimeInMillis + 1000; // countdown timer's onTick callback provides millisUntilFinished, it almost passes few millis until we get the callback and we need to display the start value value
                     new CountDownTimer(correctedAutoDismissTimeInMillis, 1000) { // show the countdown on the dialog
                         public void onTick(long millisUntilFinished) {
-                            if(messageDialog != null && messageDialog.isShowing()) {
+                            if(messageDialog!=null && messageDialog.isShowing()) {
                                 int resId = cordova.getActivity().getResources().getIdentifier(messageID, "string", cordova.getActivity().getPackageName());
                                 String message = cordova.getActivity().getString(resId, String.valueOf(millisUntilFinished / 1000));
                                 messageDialog.setMessage(message);

--- a/src/android/Zoom.java
+++ b/src/android/Zoom.java
@@ -225,13 +225,17 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
 
     private CallbackContext callbackContext;
     private CallbackContext sharedEventContext;
-    public final Handler callIgnoredHandler = new Handler();
+    private final Handler callIgnoredHandler = new Handler();
     private static Zoom mInstance = null;
 
-    public AlertDialog messageDialog;
+    private AlertDialog messageDialog;
     public static final int CALL_IGNORED_DIALOG_SHOW_AFTER_MILLIS = 90000; // Duration in millis after which we show the call ignored/missed dialog
     public static final int CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS = 8000; // Duration for which we show the call ignored/missed dialog
     private static final String CALL_STATUS_DECLINED = "call_declined";
+    public final static int ACTION_CALL_IGNORED_BY_PARTICIPANT = 1;
+    public final static int ACTION_CALL_DECLINED_BY_PARTICIPANT = 2;
+    public final static int ACTION_PARTICIPANTS_LEFT_THE_CALL = 3;
+    public final static int REORDER_WITHOUT_ACTION = 0;
 
     public static Zoom getInstance() {
         return mInstance;
@@ -1710,10 +1714,9 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
         }
     }
 
-    public final static int ACTION_CALL_IGNORED_BY_PARTICIPANT = 1;
-    public final static int ACTION_CALL_DECLINED_BY_PARTICIPANT = 2;
-    public final static int ACTION_PARTICIPANTS_LEFT_THE_CALL = 3;
-
+    private void reorderNewZoomActivity() {
+        reorderNewZoomActivity(REORDER_WITHOUT_ACTION);
+    }
     private void reorderNewZoomActivity(int action) {
         Handler mainHandler = new Handler(Looper.getMainLooper());
         // Send a task to the MessageQueue of the main thread
@@ -1728,7 +1731,9 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
                             Intent intent = new Intent(cordova.getActivity(), c);
                             intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
                             Timber.d("Putting next action as " + action);
-                            intent.putExtra("NextAction", action);
+                            if(action!=REORDER_WITHOUT_ACTION) {
+                                intent.putExtra("NextAction", action);
+                            }
                             Bundle bundleAnim =  ActivityOptions.makeCustomAnimation(cordova.getActivity(), android.R.anim.slide_in_left, android.R.anim.slide_out_right).toBundle();
                             ActivityCompat.startActivity(cordova.getContext(), intent, bundleAnim);
                         } catch (ClassNotFoundException ignored) {
@@ -1739,79 +1744,103 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
         });
     }
 
-    public void showMessageDialog(String messageID, int autoDismissTimeInMillis) {
-        cordova.getActivity().runOnUiThread(
-            new Runnable() {
-                public void run() {
-                    Context context = NewZoomMeetingActivity.getFrontActivity(); // maximised
-                    if (context == null || context instanceof ZmConfPipActivity) { // we didnt get a maximised zoom call then launch dialog on main activity
-                        context = cordova.getActivity();
-                    }
-                    Timber.d("Zoom launch call info dialog on " + context);
-                    AlertDialog.Builder builder = new AlertDialog.Builder(context, android.R.style.Theme_DeviceDefault_Dialog_MinWidth);
-                    int resId = cordova.getActivity().getResources().getIdentifier(messageID, "string", cordova.getActivity().getPackageName());
-                    builder.setMessage(cordova.getActivity().getResources().getString(resId))
-                        .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int id) {
+    public void showMessageDialog(int action) {
+            cordova.getActivity().runOnUiThread(
+                new Runnable() {
+                    public void run() {
+                        String messageID = null;
+                        int autoDismissTimeInMillis = 0;
+                        switch (action) {
+                            case ACTION_CALL_DECLINED_BY_PARTICIPANT:
+                                messageID = "zoom_call_declined_message";
+                                autoDismissTimeInMillis = CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS;
+                                break;
 
-                                Handler mainHandler = new Handler(Looper.getMainLooper());
-                                // Send a task to the MessageQueue of the main thread
-                                mainHandler.post(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        // Code will be executed on the main thread
-                                        leaveMeeting(); // As per Zoom, leave meeting should be done from main thread
+                            case Zoom.ACTION_CALL_IGNORED_BY_PARTICIPANT:
+                                messageID = "zoom_call_missed_message";
+                                autoDismissTimeInMillis = CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS;
+                                break;
+
+                            default:
+                                Timber.d("Default case: Show message dialog on zoom call");
+                        }
+                        if (!messageID.isEmpty()) {
+                            Context context = NewZoomMeetingActivity.getFrontActivity(); // maximised
+                            if (context == null || context instanceof ZmConfPipActivity) { // we didnt get a maximised zoom call then launch dialog on main activity
+                                context = cordova.getActivity();
+                            }
+                            Timber.d("Zoom launch call info dialog on " + context);
+                            AlertDialog.Builder builder = new AlertDialog.Builder(context, android.R.style.Theme_DeviceDefault_Dialog_MinWidth);
+                            int resId = cordova.getActivity().getResources().getIdentifier(messageID, "string", cordova.getActivity().getPackageName());
+                            builder.setMessage(cordova.getActivity().getResources().getString(resId))
+                                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                                    public void onClick(DialogInterface dialog, int id) {
+
+                                        Handler mainHandler = new Handler(Looper.getMainLooper());
+                                        // Send a task to the MessageQueue of the main thread
+                                        mainHandler.post(new Runnable() {
+                                            @Override
+                                            public void run() {
+                                                // Code will be executed on the main thread
+                                                leaveMeeting(); // As per Zoom, leave meeting should be done from main thread
+                                            }
+                                        });
                                     }
                                 });
-                            }
-                        });
 
-                    messageDialog = builder.create();
-                    messageDialog.setCanceledOnTouchOutside(false);
-                    messageDialog.setOnShowListener(new DialogInterface.OnShowListener() {
-                        @Override
-                        public void onShow(DialogInterface dialog) {
-                            Button btnPositive = messageDialog.getButton(Dialog.BUTTON_POSITIVE);
-                            btnPositive.setTextSize(20);
-                            btnPositive.setTextColor(Color.WHITE);
-                            btnPositive.setBackgroundColor(Color.DKGRAY);
-                        }
-                    });
-                    if(context != null && (context instanceof Activity && !((AppCompatActivity) context).isFinishing())){
-                        messageDialog.show();
-                        TextView textView = (TextView) messageDialog.findViewById(android.R.id.message);
-                        textView.setTextSize(20);
-                    } else {
-                        Timber.e("Couldnt show the zoom message dialog as activity is null or not active");
-                    }
-
-                    int correctedAutoDismissTimeInMillis = autoDismissTimeInMillis + 1000; // countdown timer's onTick callback provides millisUntilFinished, it almost passes few millis until we get the callback and we need to display the start value value
-
-                    new CountDownTimer(correctedAutoDismissTimeInMillis, 1000) { // show the countdown on the dialog
-                        public void onTick(long millisUntilFinished) {
-                            if(messageDialog!=null && messageDialog.isShowing()) {
-                                int resId = cordova.getActivity().getResources().getIdentifier(messageID, "string", cordova.getActivity().getPackageName());
-                                String message = cordova.getActivity().getString(resId, String.valueOf(millisUntilFinished / 1000));
-                                messageDialog.setMessage(message);
-                            }
-                        }
-
-                        public void onFinish() {
-                            // Create a handler that associated with Looper of the main thread
-                            Handler mainHandler = new Handler(Looper.getMainLooper());
-                            mainHandler.post(new Runnable() { // Send a task to the MessageQueue of the main thread
+                            messageDialog = builder.create();
+                            messageDialog.setCanceledOnTouchOutside(false);
+                            messageDialog.setOnShowListener(new DialogInterface.OnShowListener() {
                                 @Override
-                                public void run() {
-                                    leaveMeeting();
-                                    if (webView == null) { // Start activity if web view was destroyed, mainly when app in bg and the call is ended
-                                        startMainActivity();
-                                    }
+                                public void onShow(DialogInterface dialog) {
+                                    Button btnPositive = messageDialog.getButton(Dialog.BUTTON_POSITIVE);
+                                    btnPositive.setTextSize(20);
+                                    btnPositive.setTextColor(Color.WHITE);
+                                    btnPositive.setBackgroundColor(Color.DKGRAY);
                                 }
                             });
+                            if (context != null && (context instanceof Activity && !((AppCompatActivity) context).isFinishing())) {
+                                messageDialog.show();
+                                TextView textView = (TextView) messageDialog.findViewById(android.R.id.message);
+                                textView.setTextSize(20);
+                            } else {
+                                Timber.e("Couldnt show the zoom message dialog as activity is null or not active");
+                            }
+
+                            int correctedAutoDismissTimeInMillis = autoDismissTimeInMillis + 1000; // countdown timer's onTick callback provides millisUntilFinished, it almost passes few millis until we get the callback and we need to display the start value value
+                            String countdownMsgID = messageID;
+                            new CountDownTimer(correctedAutoDismissTimeInMillis, 1000) { // show the countdown on the dialog
+                                public void onTick(long millisUntilFinished) {
+                                    if (messageDialog != null && messageDialog.isShowing()) {
+                                        int resId = cordova.getActivity().getResources().getIdentifier(countdownMsgID, "string", cordova.getActivity().getPackageName());
+                                        String message = cordova.getActivity().getString(resId, String.valueOf(millisUntilFinished / 1000));
+                                        messageDialog.setMessage(message);
+                                    }
+                                }
+
+                                public void onFinish() {
+                                    // Create a handler that associated with Looper of the main thread
+                                    Handler mainHandler = new Handler(Looper.getMainLooper());
+                                    mainHandler.post(new Runnable() { // Send a task to the MessageQueue of the main thread
+                                        @Override
+                                        public void run() {
+                                            leaveMeeting();
+                                            if (webView == null) { // Start activity if web view was destroyed, mainly when app in bg and the call is ended
+                                                startMainActivity();
+                                            }
+                                        }
+                                    });
+                                }
+                            }.start();
                         }
-                    }.start();
+                     else
+
+                    {
+                        Timber.e("No message to be shown on zoom alert dialog");
+                    }
                 }
-            });
+                });
+
     }
 
     public void leaveMeeting() {

--- a/src/android/Zoom.java
+++ b/src/android/Zoom.java
@@ -1714,6 +1714,101 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
         }
     }
 
+    public void showMessageDialog(int action) {
+        cordova.getActivity().runOnUiThread(
+            new Runnable() {
+                public void run() {
+                    String messageID = null;
+                    int autoDismissTimeInMillis = 0;
+                    switch (action) {
+                        case ACTION_CALL_DECLINED_BY_PARTICIPANT:
+                            messageID = "zoom_call_declined_message";
+                            autoDismissTimeInMillis = CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS;
+                            break;
+
+                        case Zoom.ACTION_CALL_IGNORED_BY_PARTICIPANT:
+                            messageID = "zoom_call_missed_message";
+                            autoDismissTimeInMillis = CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS;
+                            break;
+
+                        default:
+                            Timber.d("Default case: Show message dialog on zoom call");
+                    }
+                    if (!messageID.isEmpty()) {
+                        Context context = NewZoomMeetingActivity.getFrontActivity(); // maximised
+                        if (context == null || context instanceof ZmConfPipActivity) { // we didnt get a maximised zoom call then launch dialog on main activity
+                            context = cordova.getActivity();
+                        }
+                        Timber.d("Zoom launch call info dialog on " + context);
+                        AlertDialog.Builder builder = new AlertDialog.Builder(context, android.R.style.Theme_DeviceDefault_Dialog_MinWidth);
+                        int resId = cordova.getActivity().getResources().getIdentifier(messageID, "string", cordova.getActivity().getPackageName());
+                        builder.setMessage(cordova.getActivity().getResources().getString(resId))
+                            .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                                public void onClick(DialogInterface dialog, int id) {
+
+                                    Handler mainHandler = new Handler(Looper.getMainLooper());
+                                    // Send a task to the MessageQueue of the main thread
+                                    mainHandler.post(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            // Code will be executed on the main thread
+                                            leaveMeeting(); // As per Zoom, leave meeting should be done from main thread
+                                        }
+                                    });
+                                }
+                            });
+
+                        messageDialog = builder.create();
+                        messageDialog.setCanceledOnTouchOutside(false);
+                        messageDialog.setOnShowListener(new DialogInterface.OnShowListener() {
+                            @Override
+                            public void onShow(DialogInterface dialog) {
+                                Button btnPositive = messageDialog.getButton(Dialog.BUTTON_POSITIVE);
+                                btnPositive.setTextSize(20);
+                                btnPositive.setTextColor(Color.WHITE);
+                                btnPositive.setBackgroundColor(Color.DKGRAY);
+                            }
+                        });
+                        if (context != null && (context instanceof Activity && !((AppCompatActivity) context).isFinishing())) {
+                            messageDialog.show();
+                            TextView textView = (TextView) messageDialog.findViewById(android.R.id.message);
+                            textView.setTextSize(20);
+                        } else {
+                            Timber.e("Couldnt show the zoom message dialog as activity is null or not active");
+                        }
+
+                        int correctedAutoDismissTimeInMillis = autoDismissTimeInMillis + 1000; // countdown timer's onTick callback provides millisUntilFinished, it almost passes few millis until we get the callback and we need to display the start value value
+                        String countdownMsgID = messageID;
+                        new CountDownTimer(correctedAutoDismissTimeInMillis, 1000) { // show the countdown on the dialog
+                            public void onTick(long millisUntilFinished) {
+                                if (messageDialog != null && messageDialog.isShowing()) {
+                                    int resId = cordova.getActivity().getResources().getIdentifier(countdownMsgID, "string", cordova.getActivity().getPackageName());
+                                    String message = cordova.getActivity().getString(resId, String.valueOf(millisUntilFinished / 1000));
+                                    messageDialog.setMessage(message);
+                                }
+                            }
+
+                            public void onFinish() {
+                                // Create a handler that associated with Looper of the main thread
+                                Handler mainHandler = new Handler(Looper.getMainLooper());
+                                mainHandler.post(new Runnable() { // Send a task to the MessageQueue of the main thread
+                                    @Override
+                                    public void run() {
+                                        leaveMeeting();
+                                        if (webView == null) { // Start activity if web view was destroyed, mainly when app in bg and the call is ended
+                                            startMainActivity();
+                                        }
+                                    }
+                                });
+                            }
+                        }.start();
+                    }else {
+                        Timber.e("No message to be shown on zoom alert dialog");
+                    }
+                }
+            });
+    }
+
     private void reorderNewZoomActivity(int action) {
         Handler mainHandler = new Handler(Looper.getMainLooper());
         // Send a task to the MessageQueue of the main thread
@@ -1743,105 +1838,6 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
 
     private void reorderNewZoomActivity() {
         reorderNewZoomActivity(REORDER_WITHOUT_ACTION);
-    }
-
-    public void showMessageDialog(int action) {
-            cordova.getActivity().runOnUiThread(
-                new Runnable() {
-                    public void run() {
-                        String messageID = null;
-                        int autoDismissTimeInMillis = 0;
-                        switch (action) {
-                            case ACTION_CALL_DECLINED_BY_PARTICIPANT:
-                                messageID = "zoom_call_declined_message";
-                                autoDismissTimeInMillis = CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS;
-                                break;
-
-                            case Zoom.ACTION_CALL_IGNORED_BY_PARTICIPANT:
-                                messageID = "zoom_call_missed_message";
-                                autoDismissTimeInMillis = CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS;
-                                break;
-
-                            default:
-                                Timber.d("Default case: Show message dialog on zoom call");
-                        }
-                        if (!messageID.isEmpty()) {
-                            Context context = NewZoomMeetingActivity.getFrontActivity(); // maximised
-                            if (context == null || context instanceof ZmConfPipActivity) { // we didnt get a maximised zoom call then launch dialog on main activity
-                                context = cordova.getActivity();
-                            }
-                            Timber.d("Zoom launch call info dialog on " + context);
-                            AlertDialog.Builder builder = new AlertDialog.Builder(context, android.R.style.Theme_DeviceDefault_Dialog_MinWidth);
-                            int resId = cordova.getActivity().getResources().getIdentifier(messageID, "string", cordova.getActivity().getPackageName());
-                            builder.setMessage(cordova.getActivity().getResources().getString(resId))
-                                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-                                    public void onClick(DialogInterface dialog, int id) {
-
-                                        Handler mainHandler = new Handler(Looper.getMainLooper());
-                                        // Send a task to the MessageQueue of the main thread
-                                        mainHandler.post(new Runnable() {
-                                            @Override
-                                            public void run() {
-                                                // Code will be executed on the main thread
-                                                leaveMeeting(); // As per Zoom, leave meeting should be done from main thread
-                                            }
-                                        });
-                                    }
-                                });
-
-                            messageDialog = builder.create();
-                            messageDialog.setCanceledOnTouchOutside(false);
-                            messageDialog.setOnShowListener(new DialogInterface.OnShowListener() {
-                                @Override
-                                public void onShow(DialogInterface dialog) {
-                                    Button btnPositive = messageDialog.getButton(Dialog.BUTTON_POSITIVE);
-                                    btnPositive.setTextSize(20);
-                                    btnPositive.setTextColor(Color.WHITE);
-                                    btnPositive.setBackgroundColor(Color.DKGRAY);
-                                }
-                            });
-                            if (context != null && (context instanceof Activity && !((AppCompatActivity) context).isFinishing())) {
-                                messageDialog.show();
-                                TextView textView = (TextView) messageDialog.findViewById(android.R.id.message);
-                                textView.setTextSize(20);
-                            } else {
-                                Timber.e("Couldnt show the zoom message dialog as activity is null or not active");
-                            }
-
-                            int correctedAutoDismissTimeInMillis = autoDismissTimeInMillis + 1000; // countdown timer's onTick callback provides millisUntilFinished, it almost passes few millis until we get the callback and we need to display the start value value
-                            String countdownMsgID = messageID;
-                            new CountDownTimer(correctedAutoDismissTimeInMillis, 1000) { // show the countdown on the dialog
-                                public void onTick(long millisUntilFinished) {
-                                    if (messageDialog != null && messageDialog.isShowing()) {
-                                        int resId = cordova.getActivity().getResources().getIdentifier(countdownMsgID, "string", cordova.getActivity().getPackageName());
-                                        String message = cordova.getActivity().getString(resId, String.valueOf(millisUntilFinished / 1000));
-                                        messageDialog.setMessage(message);
-                                    }
-                                }
-
-                                public void onFinish() {
-                                    // Create a handler that associated with Looper of the main thread
-                                    Handler mainHandler = new Handler(Looper.getMainLooper());
-                                    mainHandler.post(new Runnable() { // Send a task to the MessageQueue of the main thread
-                                        @Override
-                                        public void run() {
-                                            leaveMeeting();
-                                            if (webView == null) { // Start activity if web view was destroyed, mainly when app in bg and the call is ended
-                                                startMainActivity();
-                                            }
-                                        }
-                                    });
-                                }
-                            }.start();
-                        }
-                     else
-
-                    {
-                        Timber.e("No message to be shown on zoom alert dialog");
-                    }
-                }
-                });
-
     }
 
     public void leaveMeeting() {

--- a/src/android/Zoom.java
+++ b/src/android/Zoom.java
@@ -1680,37 +1680,6 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
         emitSharedJsEvent(EVENT_TYPE_MEETING_USER_JOIN, eventData);
     }
 
-    private void reorderNewZoomActivity(int action) {
-        Handler mainHandler = new Handler(Looper.getMainLooper());
-        // Send a task to the MessageQueue of the main thread
-        mainHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                InMeetingService inMeetingService = ZoomSDK.getInstance().getInMeetingService();
-                if (inMeetingService.isMeetingConnected()) {
-                    String activityToStart = "cordova.plugin.zoom.NewZoomMeetingActivity";
-                    try {
-                        Class<?> c = Class.forName(activityToStart);
-                        Intent intent = new Intent(cordova.getActivity(), c);
-                        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-                        Timber.d("Putting next action as " + action);
-                        if(action!=REORDER_WITHOUT_ACTION) {
-                            intent.putExtra("NextAction", action);
-                        }
-                        Bundle bundleAnim =  ActivityOptions.makeCustomAnimation(cordova.getActivity(), android.R.anim.slide_in_left, android.R.anim.slide_out_right).toBundle();
-                        ActivityCompat.startActivity(cordova.getContext(), intent, bundleAnim);
-                    } catch (ClassNotFoundException ignored) {
-                        Timber.e("Unable to start " + ignored);
-                    }
-                }
-            }
-        });
-    }
-
-    private void reorderNewZoomActivity() {
-        reorderNewZoomActivity(REORDER_WITHOUT_ACTION);
-    }
-
     /**
      * If the call is ignored by other participant and no one joins it, we show the maximised call view and then a
      * dialog that will auto leave the call / or user can end it by pressing ok.
@@ -1746,26 +1715,33 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
     }
 
     public void showMessageDialog(int action) {
+        String messageID = null;
+        int autoDismissTimeInMillis = 0;
+        switch (action) {
+            case ACTION_CALL_DECLINED_BY_PARTICIPANT:
+                messageID = "zoom_call_declined_message";
+                autoDismissTimeInMillis = CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS;
+                break;
+
+            case Zoom.ACTION_CALL_IGNORED_BY_PARTICIPANT:
+                messageID = "zoom_call_missed_message";
+                autoDismissTimeInMillis = CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS;
+                break;
+
+            default:
+                Timber.d("Default case: Show message dialog on zoom call");
+        }
+        if (!messageID.isEmpty()) {
+            showMessageDialog(messageID, autoDismissTimeInMillis);
+        } else {
+            Timber.e("No message to be shown on zoom alert dialog");
+        }
+    }
+
+    private void showMessageDialog(String messageID, int autoDismissTimeInMillis) {
         cordova.getActivity().runOnUiThread(
             new Runnable() {
                 public void run() {
-                    String messageID = null;
-                    int autoDismissTimeInMillis = 0;
-                    switch (action) {
-                        case ACTION_CALL_DECLINED_BY_PARTICIPANT:
-                            messageID = "zoom_call_declined_message";
-                            autoDismissTimeInMillis = CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS;
-                            break;
-
-                        case Zoom.ACTION_CALL_IGNORED_BY_PARTICIPANT:
-                            messageID = "zoom_call_missed_message";
-                            autoDismissTimeInMillis = CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS;
-                            break;
-
-                        default:
-                            Timber.d("Default case: Show message dialog on zoom call");
-                    }
-                    if (!messageID.isEmpty()) {
                         Context context = NewZoomMeetingActivity.getFrontActivity(); // maximised
                         if (context == null || context instanceof ZmConfPipActivity) { // we didnt get a maximised zoom call then launch dialog on main activity
                             context = cordova.getActivity();
@@ -1833,9 +1809,6 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
                                 });
                             }
                         }.start();
-                    }else {
-                        Timber.e("No message to be shown on zoom alert dialog");
-                    }
                 }
             });
     }
@@ -1874,6 +1847,37 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
         } catch (ClassNotFoundException ignored) {
             Timber.e("unable to start " + ignored);
         }
+    }
+
+    private void reorderNewZoomActivity(int action) {
+        Handler mainHandler = new Handler(Looper.getMainLooper());
+        // Send a task to the MessageQueue of the main thread
+        mainHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                InMeetingService inMeetingService = ZoomSDK.getInstance().getInMeetingService();
+                if (inMeetingService.isMeetingConnected()) {
+                    String activityToStart = "cordova.plugin.zoom.NewZoomMeetingActivity";
+                    try {
+                        Class<?> c = Class.forName(activityToStart);
+                        Intent intent = new Intent(cordova.getActivity(), c);
+                        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+                        Timber.d("Putting next action as " + action);
+                        if(action!=REORDER_WITHOUT_ACTION) {
+                            intent.putExtra("NextAction", action);
+                        }
+                        Bundle bundleAnim =  ActivityOptions.makeCustomAnimation(cordova.getActivity(), android.R.anim.slide_in_left, android.R.anim.slide_out_right).toBundle();
+                        ActivityCompat.startActivity(cordova.getContext(), intent, bundleAnim);
+                    } catch (ClassNotFoundException ignored) {
+                        Timber.e("Unable to start " + ignored);
+                    }
+                }
+            }
+        });
+    }
+
+    private void reorderNewZoomActivity() {
+        reorderNewZoomActivity(REORDER_WITHOUT_ACTION);
     }
 
     @Override

--- a/src/android/Zoom.java
+++ b/src/android/Zoom.java
@@ -1785,6 +1785,7 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
                     }
 
                     int correctedAutoDismissTimeInMillis = autoDismissTimeInMillis + 1000; // countdown timer's onTick callback provides millisUntilFinished, it almost passes few millis until we get the callback and we need to display the start value value
+
                     new CountDownTimer(correctedAutoDismissTimeInMillis, 1000) { // show the countdown on the dialog
                         public void onTick(long millisUntilFinished) {
                             if(messageDialog!=null && messageDialog.isShowing()) {

--- a/src/android/Zoom.java
+++ b/src/android/Zoom.java
@@ -229,8 +229,8 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
     private static Zoom mInstance = null;
 
     private AlertDialog messageDialog;
-    public static final int CALL_IGNORED_DIALOG_SHOW_AFTER_MILLIS = 90000; // Duration in millis after which we show the call ignored/missed dialog
-    public static final int CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS = 8000; // Duration for which we show the call ignored/missed dialog
+    private static final int CALL_IGNORED_DIALOG_SHOW_AFTER_MILLIS = 90000; // Duration in millis after which we show the call ignored/missed dialog
+    private static final int CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS = 8000; // Duration for which we show the call ignored/missed dialog
     private static final String CALL_STATUS_DECLINED = "call_declined";
     public final static int ACTION_CALL_IGNORED_BY_PARTICIPANT = 1;
     public final static int ACTION_CALL_DECLINED_BY_PARTICIPANT = 2;
@@ -1680,6 +1680,37 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
         emitSharedJsEvent(EVENT_TYPE_MEETING_USER_JOIN, eventData);
     }
 
+    private void reorderNewZoomActivity(int action) {
+        Handler mainHandler = new Handler(Looper.getMainLooper());
+        // Send a task to the MessageQueue of the main thread
+        mainHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                InMeetingService inMeetingService = ZoomSDK.getInstance().getInMeetingService();
+                if (inMeetingService.isMeetingConnected()) {
+                    String activityToStart = "cordova.plugin.zoom.NewZoomMeetingActivity";
+                    try {
+                        Class<?> c = Class.forName(activityToStart);
+                        Intent intent = new Intent(cordova.getActivity(), c);
+                        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+                        Timber.d("Putting next action as " + action);
+                        if(action!=REORDER_WITHOUT_ACTION) {
+                            intent.putExtra("NextAction", action);
+                        }
+                        Bundle bundleAnim =  ActivityOptions.makeCustomAnimation(cordova.getActivity(), android.R.anim.slide_in_left, android.R.anim.slide_out_right).toBundle();
+                        ActivityCompat.startActivity(cordova.getContext(), intent, bundleAnim);
+                    } catch (ClassNotFoundException ignored) {
+                        Timber.e("Unable to start " + ignored);
+                    }
+                }
+            }
+        });
+    }
+
+    private void reorderNewZoomActivity() {
+        reorderNewZoomActivity(REORDER_WITHOUT_ACTION);
+    }
+
     /**
      * If the call is ignored by other participant and no one joins it, we show the maximised call view and then a
      * dialog that will auto leave the call / or user can end it by pressing ok.
@@ -1807,37 +1838,6 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
                     }
                 }
             });
-    }
-
-    private void reorderNewZoomActivity(int action) {
-        Handler mainHandler = new Handler(Looper.getMainLooper());
-        // Send a task to the MessageQueue of the main thread
-        mainHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                InMeetingService inMeetingService = ZoomSDK.getInstance().getInMeetingService();
-                if (inMeetingService.isMeetingConnected()) {
-                        String activityToStart = "cordova.plugin.zoom.NewZoomMeetingActivity";
-                        try {
-                            Class<?> c = Class.forName(activityToStart);
-                            Intent intent = new Intent(cordova.getActivity(), c);
-                            intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-                            Timber.d("Putting next action as " + action);
-                            if(action!=REORDER_WITHOUT_ACTION) {
-                                intent.putExtra("NextAction", action);
-                            }
-                            Bundle bundleAnim =  ActivityOptions.makeCustomAnimation(cordova.getActivity(), android.R.anim.slide_in_left, android.R.anim.slide_out_right).toBundle();
-                            ActivityCompat.startActivity(cordova.getContext(), intent, bundleAnim);
-                        } catch (ClassNotFoundException ignored) {
-                            Timber.e("Unable to start " + ignored);
-                        }
-                }
-            }
-        });
-    }
-
-    private void reorderNewZoomActivity() {
-        reorderNewZoomActivity(REORDER_WITHOUT_ACTION);
     }
 
     public void leaveMeeting() {

--- a/src/android/Zoom.java
+++ b/src/android/Zoom.java
@@ -225,12 +225,12 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
 
     private CallbackContext callbackContext;
     private CallbackContext sharedEventContext;
-    private final Handler callIgnoredHandler = new Handler();
+    public final Handler callIgnoredHandler = new Handler();
     private static Zoom mInstance = null;
 
-    private AlertDialog messageDialog;
-    private static final int CALL_IGNORED_DIALOG_SHOW_AFTER_MILLIS = 90000; // Duration in millis after which we show the call ignored/missed dialog
-    private static final int CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS = 8000; // Duration for which we show the call ignored/missed dialog
+    public AlertDialog messageDialog;
+    public static final int CALL_IGNORED_DIALOG_SHOW_AFTER_MILLIS = 90000; // Duration in millis after which we show the call ignored/missed dialog
+    public static final int CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS = 8000; // Duration for which we show the call ignored/missed dialog
     private static final String CALL_STATUS_DECLINED = "call_declined";
 
     public static Zoom getInstance() {
@@ -360,25 +360,8 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
     private void handleCallStatusUpdate(String callStatus) {
         if (callStatus!=null && callStatus.equals(CALL_STATUS_DECLINED)) {
             // when call is declined, and call is on, show the NewZoomMeeting first and then launch the dialog
-
-            Handler mainHandler = new Handler(Looper.getMainLooper());
-            // Send a task to the MessageQueue of the main thread
-            mainHandler.post(new Runnable() {
-                @Override
-                public void run() {
-                    Timber.d("OnGoing Zoom call received declined from other party, meeting in progress, show NewZoomMeetingActivity");
-                    reorderNewZoomActivity();
-                }
-            });
-
-            mainHandler.postDelayed(new Runnable()
-            {
-                @Override
-                public void run()    {
-                    showMessageDialog("zoom_call_declined_message", CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS);
-                }
-            }, 1000);
-
+            Timber.d("OnGoing Zoom call received declined from other party, meeting in progress, show NewZoomMeetingActivity");
+            reorderNewZoomActivity(ACTION_CALL_DECLINED_BY_PARTICIPANT);
         }
     }
 
@@ -1698,28 +1681,8 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
      * dialog that will auto leave the call / or user can end it by pressing ok.
      */
     private void checkCallIgnoredByParticipant() {
-
-        Handler mainHandler = new Handler(Looper.getMainLooper());
-        // Send a task to the MessageQueue of the main thread
-        mainHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                    Timber.d("Call ignored by participant, meeting in progress, show NewZoomMeetingActivity");
-                    reorderNewZoomActivity();
-            }
-        });
-
-        mainHandler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                    InMeetingService meetingService = ZoomSDK.getInstance().getInMeetingService();
-                    List<Long> currentUserList = meetingService.getInMeetingUserList();
-                    if (meetingService != null && currentUserList != null && currentUserList.size() <= 1) {
-                        showMessageDialog("zoom_call_missed_message", CALL_IGNORED_DIALOG_SHOW_DURATION_MILLIS); // inform user that call was ignored/missed by the other participant
-                    }
-            }
-        }, 1000);
-
+        Timber.d("Call ignored by participant, meeting in progress, show NewZoomMeetingActivity");
+        reorderNewZoomActivity(ACTION_CALL_IGNORED_BY_PARTICIPANT);
     }
 
     @Override
@@ -1742,42 +1705,38 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
 
         emitSharedJsEvent(EVENT_TYPE_MEETING_USER_LEAVE, eventData);
         if (currentUserList !=null && currentUserList.size() == 1) {
-            
-            Handler mainHandler = new Handler(Looper.getMainLooper());
-            // Send a task to the MessageQueue of the main thread
-            mainHandler.post(new Runnable() {
-                @Override
-                public void run() {
-                        Timber.d("Call left by all other participants, meeting in progress, show NewZoomMeetingActivity");
-                        reorderNewZoomActivity();
-                }
-            });
-
-            // End the call as the user is the last participant left
-            mainHandler.postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    leaveMeeting();
-                }
-            }, 1000);
-
+            Timber.d("Call left by all other participants, meeting in progress, show NewZoomMeetingActivity");
+            reorderNewZoomActivity(ACTION_PARTICIPANTS_LEFT_THE_CALL);
         }
     }
 
-    private void reorderNewZoomActivity() {
-        InMeetingService inMeetingService = ZoomSDK.getInstance().getInMeetingService();
-        if (inMeetingService.isMeetingConnected()) {
-            String activityToStart = "cordova.plugin.zoom.NewZoomMeetingActivity";
-            try {
-                Class<?> c = Class.forName(activityToStart);
-                Intent intent = new Intent(cordova.getActivity(), c);
-                intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-                Bundle bundleAnim =  ActivityOptions.makeCustomAnimation(cordova.getActivity(), android.R.anim.slide_in_left, android.R.anim.slide_out_right).toBundle();
-                ActivityCompat.startActivity(cordova.getContext(), intent, bundleAnim);
-            } catch (ClassNotFoundException ignored) {
-                Timber.e("Unable to start " + ignored);
+    public final static int ACTION_CALL_IGNORED_BY_PARTICIPANT = 1;
+    public final static int ACTION_CALL_DECLINED_BY_PARTICIPANT = 2;
+    public final static int ACTION_PARTICIPANTS_LEFT_THE_CALL = 3;
+
+    private void reorderNewZoomActivity(int action) {
+        Handler mainHandler = new Handler(Looper.getMainLooper());
+        // Send a task to the MessageQueue of the main thread
+        mainHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                InMeetingService inMeetingService = ZoomSDK.getInstance().getInMeetingService();
+                if (inMeetingService.isMeetingConnected()) {
+                        String activityToStart = "cordova.plugin.zoom.NewZoomMeetingActivity";
+                        try {
+                            Class<?> c = Class.forName(activityToStart);
+                            Intent intent = new Intent(cordova.getActivity(), c);
+                            intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+                            Timber.d("Putting next action as " + action);
+                            intent.putExtra("NextAction", action);
+                            Bundle bundleAnim =  ActivityOptions.makeCustomAnimation(cordova.getActivity(), android.R.anim.slide_in_left, android.R.anim.slide_out_right).toBundle();
+                            ActivityCompat.startActivity(cordova.getContext(), intent, bundleAnim);
+                        } catch (ClassNotFoundException ignored) {
+                            Timber.e("Unable to start " + ignored);
+                        }
+                }
             }
-        }
+        });
     }
 
     public void showMessageDialog(String messageID, int autoDismissTimeInMillis) {

--- a/src/android/Zoom.java
+++ b/src/android/Zoom.java
@@ -1714,9 +1714,6 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
         }
     }
 
-    private void reorderNewZoomActivity() {
-        reorderNewZoomActivity(REORDER_WITHOUT_ACTION);
-    }
     private void reorderNewZoomActivity(int action) {
         Handler mainHandler = new Handler(Looper.getMainLooper());
         // Send a task to the MessageQueue of the main thread
@@ -1742,6 +1739,10 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
                 }
             }
         });
+    }
+
+    private void reorderNewZoomActivity() {
+        reorderNewZoomActivity(REORDER_WITHOUT_ACTION);
     }
 
     public void showMessageDialog(int action) {

--- a/src/android/Zoom.java
+++ b/src/android/Zoom.java
@@ -1742,73 +1742,73 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
         cordova.getActivity().runOnUiThread(
             new Runnable() {
                 public void run() {
-                        Context context = NewZoomMeetingActivity.getFrontActivity(); // maximised
-                        if (context == null || context instanceof ZmConfPipActivity) { // we didnt get a maximised zoom call then launch dialog on main activity
-                            context = cordova.getActivity();
-                        }
-                        Timber.d("Zoom launch call info dialog on " + context);
-                        AlertDialog.Builder builder = new AlertDialog.Builder(context, android.R.style.Theme_DeviceDefault_Dialog_MinWidth);
-                        int resId = cordova.getActivity().getResources().getIdentifier(messageID, "string", cordova.getActivity().getPackageName());
-                        builder.setMessage(cordova.getActivity().getResources().getString(resId))
-                            .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-                                public void onClick(DialogInterface dialog, int id) {
+                    Context context = NewZoomMeetingActivity.getFrontActivity(); // maximised
+                    if (context == null || context instanceof ZmConfPipActivity) { // we didnt get a maximised zoom call then launch dialog on main activity
+                        context = cordova.getActivity();
+                    }
+                    Timber.d("Zoom launch call info dialog on " + context);
+                    AlertDialog.Builder builder = new AlertDialog.Builder(context, android.R.style.Theme_DeviceDefault_Dialog_MinWidth);
+                    int resId = cordova.getActivity().getResources().getIdentifier(messageID, "string", cordova.getActivity().getPackageName());
+                    builder.setMessage(cordova.getActivity().getResources().getString(resId))
+                        .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int id) {
 
-                                    Handler mainHandler = new Handler(Looper.getMainLooper());
-                                    // Send a task to the MessageQueue of the main thread
-                                    mainHandler.post(new Runnable() {
-                                        @Override
-                                        public void run() {
-                                            // Code will be executed on the main thread
-                                            leaveMeeting(); // As per Zoom, leave meeting should be done from main thread
-                                        }
-                                    });
-                                }
-                            });
-
-                        messageDialog = builder.create();
-                        messageDialog.setCanceledOnTouchOutside(false);
-                        messageDialog.setOnShowListener(new DialogInterface.OnShowListener() {
-                            @Override
-                            public void onShow(DialogInterface dialog) {
-                                Button btnPositive = messageDialog.getButton(Dialog.BUTTON_POSITIVE);
-                                btnPositive.setTextSize(20);
-                                btnPositive.setTextColor(Color.WHITE);
-                                btnPositive.setBackgroundColor(Color.DKGRAY);
-                            }
-                        });
-                        if (context != null && (context instanceof Activity && !((AppCompatActivity) context).isFinishing())) {
-                            messageDialog.show();
-                            TextView textView = (TextView) messageDialog.findViewById(android.R.id.message);
-                            textView.setTextSize(20);
-                        } else {
-                            Timber.e("Couldnt show the zoom message dialog as activity is null or not active");
-                        }
-
-                        int correctedAutoDismissTimeInMillis = autoDismissTimeInMillis + 1000; // countdown timer's onTick callback provides millisUntilFinished, it almost passes few millis until we get the callback and we need to display the start value value
-                        String countdownMsgID = messageID;
-                        new CountDownTimer(correctedAutoDismissTimeInMillis, 1000) { // show the countdown on the dialog
-                            public void onTick(long millisUntilFinished) {
-                                if (messageDialog != null && messageDialog.isShowing()) {
-                                    int resId = cordova.getActivity().getResources().getIdentifier(countdownMsgID, "string", cordova.getActivity().getPackageName());
-                                    String message = cordova.getActivity().getString(resId, String.valueOf(millisUntilFinished / 1000));
-                                    messageDialog.setMessage(message);
-                                }
-                            }
-
-                            public void onFinish() {
-                                // Create a handler that associated with Looper of the main thread
                                 Handler mainHandler = new Handler(Looper.getMainLooper());
-                                mainHandler.post(new Runnable() { // Send a task to the MessageQueue of the main thread
+                                // Send a task to the MessageQueue of the main thread
+                                mainHandler.post(new Runnable() {
                                     @Override
                                     public void run() {
-                                        leaveMeeting();
-                                        if (webView == null) { // Start activity if web view was destroyed, mainly when app in bg and the call is ended
-                                            startMainActivity();
-                                        }
+                                        // Code will be executed on the main thread
+                                        leaveMeeting(); // As per Zoom, leave meeting should be done from main thread
                                     }
                                 });
                             }
-                        }.start();
+                        });
+
+                    messageDialog = builder.create();
+                    messageDialog.setCanceledOnTouchOutside(false);
+                    messageDialog.setOnShowListener(new DialogInterface.OnShowListener() {
+                        @Override
+                        public void onShow(DialogInterface dialog) {
+                            Button btnPositive = messageDialog.getButton(Dialog.BUTTON_POSITIVE);
+                            btnPositive.setTextSize(20);
+                            btnPositive.setTextColor(Color.WHITE);
+                            btnPositive.setBackgroundColor(Color.DKGRAY);
+                        }
+                    });
+                    if (context != null && (context instanceof Activity && !((AppCompatActivity) context).isFinishing())) {
+                        messageDialog.show();
+                        TextView textView = (TextView) messageDialog.findViewById(android.R.id.message);
+                        textView.setTextSize(20);
+                    } else {
+                        Timber.e("Couldnt show the zoom message dialog as activity is null or not active");
+                    }
+
+                    int correctedAutoDismissTimeInMillis = autoDismissTimeInMillis + 1000; // countdown timer's onTick callback provides millisUntilFinished, it almost passes few millis until we get the callback and we need to display the start value value
+                    String countdownMsgID = messageID;
+                    new CountDownTimer(correctedAutoDismissTimeInMillis, 1000) { // show the countdown on the dialog
+                        public void onTick(long millisUntilFinished) {
+                            if (messageDialog != null && messageDialog.isShowing()) {
+                                int resId = cordova.getActivity().getResources().getIdentifier(countdownMsgID, "string", cordova.getActivity().getPackageName());
+                                String message = cordova.getActivity().getString(resId, String.valueOf(millisUntilFinished / 1000));
+                                messageDialog.setMessage(message);
+                            }
+                        }
+
+                        public void onFinish() {
+                            // Create a handler that associated with Looper of the main thread
+                            Handler mainHandler = new Handler(Looper.getMainLooper());
+                            mainHandler.post(new Runnable() { // Send a task to the MessageQueue of the main thread
+                                @Override
+                                public void run() {
+                                    leaveMeeting();
+                                    if (webView == null) { // Start activity if web view was destroyed, mainly when app in bg and the call is ended
+                                        startMainActivity();
+                                    }
+                                }
+                            });
+                        }
+                    }.start();
                 }
             });
     }


### PR DESCRIPTION
With this MR, following has been done,
- When ZmConfPiPAcitivity (PIP mode) is on (when we minimise the video call) and then leave meeting is done, this is recreating our app. Due to this, firebase instance is de-initialized and thus though the android native layer is receiving the push notifications, those are kept in buffer and not sent to the ionic layer where it could be shown.
- We needed to stop this activity/app re-creation and thus as a solution and a clean user flow (to overcome limitations we are dealing with lack of clearer documentation and support of Zoom SDK with Ionic to a different simpler approach as follows):

1. When patient minimized the zoom call and we see our app
2. When clinician declines the call, we maximise the call again, 
3. Then show the alert dialog (that call was declined) and on the maximised call's alert dialog, user now can take an action of pressing Ok button or wait for the call to auto end after 8 seconds.