### PR TITLE
DEV-18386 -  Multiple patient initiated call attempts are ending.

### DIFF
--- a/src/android/Zoom.java
+++ b/src/android/Zoom.java
@@ -373,8 +373,10 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
                 break;
             case ACTION_NOTIFY_CALL_STATUS:
                 String callStatus = args.getString(0);
-                declinedCallId = args.getString(1);
-                Timber.d("Decline call id: " + declinedCallId);
+                if(callStatus.equals(CALL_STATUS_DECLINED)){
+                    declinedCallId = args.getString(1);
+                    Timber.d("Decline call id: " + declinedCallId);
+                }
                 handleCallStatusUpdate(callStatus);
                 break;
 


### PR DESCRIPTION
Fixed below issue- 

When a clinician ignores an incoming Zoom video call, the call disconnects in PCMT after 90 seconds. If the patient tries to call the clinician again, the second attempt shows a call declined message with an 8-second countdown alert, and the call disconnects in PCMT even though the clinician did not decline the call in CC2.