### PR TITLE
DEV-20777 : [KC/KM PCMT] Missing “Waiting for Other Participants to Join” Message on PCMT When Video Call Not Accepted on CC2

### DIFF
--- a/src/android/NewZoomMeetingActivity.java
+++ b/src/android/NewZoomMeetingActivity.java
@@ -148,6 +148,7 @@ public class NewZoomMeetingActivity extends NewMeetingActivity {
                 ViewParent parent = userWaitingLayout.getParent();
                 ((ViewGroup) parent).removeView(userWaitingLayout);
             }
+            containerInConf.addView(userWaitingLayout);
         } else {
             containerInConf.removeView(userWaitingLayout);
         }


### PR DESCRIPTION
Re-added waiting message which got accidentally removed while cutting off the blocker branch -> https://github.com/healthrecoverysolutions/hrs-zoom-sdk-ionic/commit/380c62ea6c14715bfbb58e59a260ee12d4e4009e