### PR TITLE
Fixed DEV-21298 : Issue while calling clinician from PCM/T android

### DIFF
--- a/src/android/Zoom.java
+++ b/src/android/Zoom.java
@@ -1614,7 +1614,7 @@ public class Zoom extends CordovaPlugin implements ZoomSDKAuthenticationListener
     public void onMeetingLeaveComplete(long l) {
         try {
             if (webView != null) {
-                String event = "javascript:cordova.plugin.Zoom.fireMeetingLeftEvent()";
+                String event = "javascript:cordova.plugins.Zoom.fireMeetingLeftEvent()";
                 webView.loadUrl(event);
             }
             InMeetingService inMeetingService = ZoomSDK.getInstance().getInMeetingService();


### PR DESCRIPTION
Fixed the issue where user was not able to place calls from PCM/T due to the broken JS - native side communication. This happened when after opening the app, the first call was made and user left the call. Due to the broken code [javascript:cordova.plugins.Zoom.fireMeetingLeftEvent()] wrong id for zoom, native code was not calling JS side code and leave event was not handled completely. Thus communication service was considering a call is still in progress and blocking the next ones. 